### PR TITLE
Feat/no ticket/fix login

### DIFF
--- a/CucumberJs/features/extended_debugging_demo.feature
+++ b/CucumberJs/features/extended_debugging_demo.feature
@@ -5,4 +5,4 @@ Feature: Is Performance captured?
         Given I am testing extended debugging on webpage
         Then I check for sauce:performance logs
         Then I assert that pageLoad is not degraded using sauce:performance custom command
-        Then I assert that speedIndex is not degraded using sauce:performance custom command
+        Then I assert that timeToFirstInteractive is not degraded using sauce:performance custom command

--- a/CucumberJs/features/step_definitions/stepdeefs.js
+++ b/CucumberJs/features/step_definitions/stepdeefs.js
@@ -34,7 +34,10 @@ Then('I assert that pageLoad is not degraded using sauce:performance custom comm
 		name: this.testName,
 		metrics: [metric],
 	});
-	assert.equal(output.result, 'pass', output.reason);
+	const { reason, result, details } = output;
+	return result !== 'pass'
+		? assert.equal(details[metric].actual < 5000, true, reason)
+		: assert(result, 'pass');
 });
 
 Then('I assert that timeToFirstInteractive is not degraded using sauce:performance custom command', async function test() {
@@ -44,9 +47,7 @@ Then('I assert that timeToFirstInteractive is not degraded using sauce:performan
 		metrics: [metric],
 	});
 	const { reason, result, details } = output;
-	if (result !== 'pass') {
-		assert.equal(details[metric].actual < 5000, true, reason);
-		return;
-	}
-	assert(result, 'pass');
+	return result !== 'pass'
+		? assert.equal(details[metric].actual < 5000, true, reason)
+		: assert(result, 'pass');
 });

--- a/CucumberJs/features/step_definitions/stepdeefs.js
+++ b/CucumberJs/features/step_definitions/stepdeefs.js
@@ -7,7 +7,7 @@ Given('I am testing extended debugging on webpage', async function test() {
 	await username.setValue(process.env.PERF_USERNAME || 'standard_user');
 	const password = await this.browser.$('[data-test="password"]');
 	await password.setValue('secret_sauce');
-	const login = await this.browser.$('.login-button');
+	const login = await this.browser.$('.btn_action');
 	await login.click();
 	await this.browser.url('https://www.saucedemo.com/inventory.html');
 });
@@ -36,10 +36,10 @@ Then('I assert that pageLoad is not degraded using sauce:performance custom comm
 	assert.equal(output.result, 'pass', output.reason);
 });
 
-Then('I assert that speedIndex is not degraded using sauce:performance custom command', async function test() {
+Then('I assert that timeToFirstInteractive is not degraded using sauce:performance custom command', async function test() {
 	const output = await this.browser.execute('sauce:performance', {
 		name: this.testName,
-		metrics: ['speedIndex'],
+		metrics: ['timeToFirstInteractive'],
 	});
 	assert.equal(output.result, 'pass', output.reason);
 });

--- a/CucumberJs/features/step_definitions/stepdeefs.js
+++ b/CucumberJs/features/step_definitions/stepdeefs.js
@@ -35,6 +35,12 @@ Then('I assert that pageLoad is not degraded using sauce:performance custom comm
 		metrics: [metric],
 	});
 	const { reason, result, details } = output;
+	/* The custom command will return 'pass' if the test falls within the predicted baseline
+	 * or 'fail'  if the performance metric falls outside the predicted baseline.
+	 * customers can decide how strict they want to be in failing tests by setting thier own
+	 * failure points.
+	 * assert(details[metric].actual < 5000, true, reason);
+	 */
 	return result !== 'pass'
 		? assert.equal(details[metric].actual < 5000, true, reason)
 		: assert(result, 'pass');
@@ -47,6 +53,7 @@ Then('I assert that timeToFirstInteractive is not degraded using sauce:performan
 		metrics: [metric],
 	});
 	const { reason, result, details } = output;
+
 	return result !== 'pass'
 		? assert.equal(details[metric].actual < 5000, true, reason)
 		: assert(result, 'pass');

--- a/CucumberJs/features/step_definitions/stepdeefs.js
+++ b/CucumberJs/features/step_definitions/stepdeefs.js
@@ -29,17 +29,24 @@ Then('I check for sauce:performance logs', async function test() {
 });
 
 Then('I assert that pageLoad is not degraded using sauce:performance custom command', async function test() {
+	const metric = 'load';
 	const output = await this.browser.execute('sauce:performance', {
 		name: this.testName,
-		metrics: ['load'],
+		metrics: [metric],
 	});
 	assert.equal(output.result, 'pass', output.reason);
 });
 
 Then('I assert that timeToFirstInteractive is not degraded using sauce:performance custom command', async function test() {
+	const metric = 'timeToFirstInteractive';
 	const output = await this.browser.execute('sauce:performance', {
 		name: this.testName,
-		metrics: ['timeToFirstInteractive'],
+		metrics: [metric],
 	});
-	assert.equal(output.result, 'pass', output.reason);
+	const { reason, result, details } = output;
+	if (result !== 'pass') {
+		assert.equal(details[metric].actual < 5000, true, reason);
+		return;
+	}
+	assert(result, 'pass');
 });

--- a/NightWatch/tests/performance.js
+++ b/NightWatch/tests/performance.js
@@ -7,7 +7,7 @@ module.exports = {
 			.waitForElementVisible('body', 1000)
 			.setValue('input[data-test="username"]', process.env.PERF_USERNAME || 'standard_user')
 			.setValue('input[data-test="password"]', 'secret_sauce')
-			.click('.login-button')
+			.click('.btn_action')
 			.url('https://www.saucedemo.com/inventory.html')
 			.waitForElementVisible('body', 1000)
 			.getLog('sauce:performance', (performance) => {
@@ -32,7 +32,7 @@ module.exports = {
 			})
 			.execute('sauce:performance', {
 				name: browser.currentTest.name,
-				metrics: ['speedIndex'],
+				metrics: ['timeToFirstInteractive'],
 			}, ({ value }) => {
 				assert.equal(value.result, 'pass', value.reason);
 			});

--- a/NightWatch/tests/performance.js
+++ b/NightWatch/tests/performance.js
@@ -29,22 +29,18 @@ module.exports = {
 				metrics: ['load'],
 			}, ({ value }) => {
 				const { reason, result, details } = value;
-				if (result !== 'pass') {
-					assert.equal(details.load.actual < 5000, true, reason);
-					return;
-				}
-				assert(result, 'pass');
+				return result !== 'pass'
+					? assert.equal(details.load.actual < 5000, true, reason)
+					: assert(result, 'pass');
 			})
 			.execute('sauce:performance', {
 				name: browser.currentTest.name,
 				metrics: ['timeToFirstInteractive'],
 			}, ({ value }) => {
 				const { reason, result, details } = value;
-				if (result !== 'pass') {
-					assert.equal(details.timeToFirstInteractive.actual < 5000, true, reason);
-					return;
-				}
-				assert(result, 'pass');
+				return result !== 'pass'
+					? assert.equal(details.timeToFirstInteractive.actual < 5000, true, reason)
+					: assert(result, 'pass');
 			});
 	},
 

--- a/NightWatch/tests/performance.js
+++ b/NightWatch/tests/performance.js
@@ -28,13 +28,23 @@ module.exports = {
 				name: browser.currentTest.name,
 				metrics: ['load'],
 			}, ({ value }) => {
-				assert.equal(value.result, 'pass', value.reason);
+				const { reason, result, details } = value;
+				if (result !== 'pass') {
+					assert.equal(details.load.actual < 5000, true, reason);
+					return;
+				}
+				assert(result, 'pass');
 			})
 			.execute('sauce:performance', {
 				name: browser.currentTest.name,
 				metrics: ['timeToFirstInteractive'],
 			}, ({ value }) => {
-				assert.equal(value.result, 'pass', value.reason);
+				const { reason, result, details } = value;
+				if (result !== 'pass') {
+					assert.equal(details.timeToFirstInteractive.actual < 5000, true, reason);
+					return;
+				}
+				assert(result, 'pass');
 			});
 	},
 

--- a/NightWatch/tests/performance.js
+++ b/NightWatch/tests/performance.js
@@ -29,6 +29,12 @@ module.exports = {
 				metrics: ['load'],
 			}, ({ value }) => {
 				const { reason, result, details } = value;
+				/* The custom command will return 'pass' if the test falls within the predicted baseline
+ 				 * or 'fail'  if the performance metric falls outside the predicted baseline.
+ 				 * customers can decide how strict they want to be in failing tests by setting thier own
+ 				 * failure points.
+ 				 * assert(details[metric].actual < 5000, true, reason);
+  			 */
 				return result !== 'pass'
 					? assert.equal(details.load.actual < 5000, true, reason)
 					: assert(result, 'pass');

--- a/ProtactorJs/specs/performance_spec.js
+++ b/ProtactorJs/specs/performance_spec.js
@@ -7,7 +7,7 @@ describe('Performance Testing', () => {
 		browser.get('/');
 		element(by.css('[data-test="username"]')).sendKeys(process.env.PERF_USERNAME || 'standard_user');
 		element(by.css('[data-test="password"]')).sendKeys('secret_sauce');
-		element(by.css('.login-button')).click();
+		element(by.css('.btn_action')).click();
 		browser.get('/inventory.html');
 	});
 
@@ -35,10 +35,10 @@ describe('Performance Testing', () => {
 		assert.equal(output.result, 'pass', output.reason);
 	});
 
-	it('(sauce:performance) custom command should assert speedIndex has not regressed', async () => {
+	it('(sauce:performance) custom command should assert timeToFirstInteractive has not regressed', async () => {
 		const output = await browser.executeScript('sauce:performance', {
 			name: config.capabilities.name,
-			metrics: ['speedIndex'],
+			metrics: ['timeToFirstInteractive'],
 		});
 		assert.equal(output.result, 'pass', output.reason);
 	});

--- a/ProtactorJs/specs/performance_spec.js
+++ b/ProtactorJs/specs/performance_spec.js
@@ -34,12 +34,9 @@ describe('Performance Testing', () => {
 			metrics: [metric],
 		});
 		const { reason, result, details } = output;
-		// it the test returns a failure, make sure the timeToFirstInteractive is not over 5s
-		if (result !== 'pass') {
-			assert.equal(details[metric].actual < 5000, true, reason);
-			return;
-		}
-		assert(result, 'pass');
+		return result !== 'pass'
+			? assert.equal(details[metric].actual < 5000, true, reason)
+			: assert(result, 'pass');
 	});
 
 	it('(sauce:performance) custom command should assert timeToFirstInteractive has not regressed', async () => {
@@ -49,11 +46,8 @@ describe('Performance Testing', () => {
 			metrics: [metric],
 		});
 		const { reason, result, details } = output;
-		// it the test returns a failure, make sure the timeToFirstInteractive is not over 5s
-		if (result !== 'pass') {
-			assert.equal(details[metric].actual < 5000, true, reason);
-			return;
-		}
-		assert(result, 'pass');
+		return result !== 'pass'
+			? assert.equal(details[metric].actual < 5000, true, reason)
+			: assert(result, 'pass');
 	});
 });

--- a/ProtactorJs/specs/performance_spec.js
+++ b/ProtactorJs/specs/performance_spec.js
@@ -34,6 +34,12 @@ describe('Performance Testing', () => {
 			metrics: [metric],
 		});
 		const { reason, result, details } = output;
+		/* The custom command will return 'pass' if the test falls within the predicted baseline
+		 * or 'fail'  if the performance metric falls outside the predicted baseline.
+		 * customers can decide how strict they want to be in failing tests by setting thier own
+		 * failure points.
+		 * assert(details[metric].actual < 5000, true, reason);
+	 	 */
 		return result !== 'pass'
 			? assert.equal(details[metric].actual < 5000, true, reason)
 			: assert(result, 'pass');

--- a/ProtactorJs/specs/performance_spec.js
+++ b/ProtactorJs/specs/performance_spec.js
@@ -28,18 +28,32 @@ describe('Performance Testing', () => {
 	});
 
 	it('(sauce:performance) custom command should assert performance has not regressed', async () => {
+		const metric = 'load';
 		const output = await browser.executeScript('sauce:performance', {
 			name: config.capabilities.name,
-			metrics: ['load'],
+			metrics: [metric],
 		});
-		assert.equal(output.result, 'pass', output.reason);
+		const { reason, result, details } = output;
+		// it the test returns a failure, make sure the timeToFirstInteractive is not over 5s
+		if (result !== 'pass') {
+			assert.equal(details[metric].actual < 5000, true, reason);
+			return;
+		}
+		assert(result, 'pass');
 	});
 
 	it('(sauce:performance) custom command should assert timeToFirstInteractive has not regressed', async () => {
+		const metric = ['timeToFirstInteractive'];
 		const output = await browser.executeScript('sauce:performance', {
 			name: config.capabilities.name,
-			metrics: ['timeToFirstInteractive'],
+			metrics: [metric],
 		});
-		assert.equal(output.result, 'pass', output.reason);
+		const { reason, result, details } = output;
+		// it the test returns a failure, make sure the timeToFirstInteractive is not over 5s
+		if (result !== 'pass') {
+			assert.equal(details[metric].actual < 5000, true, reason);
+			return;
+		}
+		assert(result, 'pass');
 	});
 });

--- a/WebDriver.io/tests/performance.js
+++ b/WebDriver.io/tests/performance.js
@@ -8,7 +8,7 @@ describe('Performance Testing', function () { // eslint-disable-line func-names
 		username.setValue(process.env.PERF_USERNAME || 'standard_user');
 		const password = $('[data-test="password"]');
 		password.setValue('secret_sauce');
-		const loginButton = $('.login-button');
+		const loginButton = $('.btn_action');
 		loginButton.click();
 		browser.url('/inventory.html');
 	});
@@ -37,10 +37,10 @@ describe('Performance Testing', function () { // eslint-disable-line func-names
 		assert.equal(output.result, 'pass');
 	});
 
-	it('(sauce:performance) custom command should assert speedIndex has not regressed', () => {
+	it('(sauce:performance) custom command should assert timeToFirstInteractive has not regressed', () => {
 		const output = browser.execute('sauce:performance', {
 			name: title,
-			metrics: ['speedIndex'],
+			metrics: ['timeToFirstInteractive'],
 		});
 		assert.equal(output.result, 'pass');
 	});

--- a/WebDriver.io/tests/performance.js
+++ b/WebDriver.io/tests/performance.js
@@ -30,18 +30,32 @@ describe('Performance Testing', function () { // eslint-disable-line func-names
 	});
 
 	it('(sauce:performance) custom command should assert pageload has not regressed', () => {
+		const metric = 'load';
 		const output = browser.execute('sauce:performance', {
 			name: title,
-			metrics: ['load'],
+			metrics: [metric],
 		});
-		assert.equal(output.result, 'pass');
+		const { reason, result, details } = output;
+		// it the test returns a failure, make sure the load time is not over 5s
+		if (result !== 'pass') {
+			assert.equal(details[metric.actual] < 5000, true, reason);
+			return;
+		}
+		assert(result, 'pass');
 	});
 
 	it('(sauce:performance) custom command should assert timeToFirstInteractive has not regressed', () => {
+		const metric = 'load';
 		const output = browser.execute('sauce:performance', {
 			name: title,
-			metrics: ['timeToFirstInteractive'],
+			metrics: [metric],
 		});
-		assert.equal(output.result, 'pass');
+		const { reason, result, details } = output;
+		// it the test returns a failure, make sure the timeToFirstInteractive is not over 5s
+		if (result !== 'pass') {
+			assert.equal(details[metric].actual < 5000, true, reason);
+			return;
+		}
+		assert(result, 'pass');
 	});
 });

--- a/WebDriver.io/tests/performance.js
+++ b/WebDriver.io/tests/performance.js
@@ -36,12 +36,9 @@ describe('Performance Testing', function () { // eslint-disable-line func-names
 			metrics: [metric],
 		});
 		const { reason, result, details } = output;
-		// it the test returns a failure, make sure the load time is not over 5s
-		if (result !== 'pass') {
-			assert.equal(details[metric.actual] < 5000, true, reason);
-			return;
-		}
-		assert(result, 'pass');
+		return result !== 'pass'
+			? assert.equal(details[metric].actual < 5000, true, reason)
+			: assert(result, 'pass');
 	});
 
 	it('(sauce:performance) custom command should assert timeToFirstInteractive has not regressed', () => {
@@ -51,11 +48,8 @@ describe('Performance Testing', function () { // eslint-disable-line func-names
 			metrics: [metric],
 		});
 		const { reason, result, details } = output;
-		// it the test returns a failure, make sure the timeToFirstInteractive is not over 5s
-		if (result !== 'pass') {
-			assert.equal(details[metric].actual < 5000, true, reason);
-			return;
-		}
-		assert(result, 'pass');
+		return result !== 'pass'
+			? assert.equal(details[metric].actual < 5000, true, reason)
+			: assert(result, 'pass');
 	});
 });

--- a/WebDriver.io/tests/performance.js
+++ b/WebDriver.io/tests/performance.js
@@ -36,6 +36,12 @@ describe('Performance Testing', function () { // eslint-disable-line func-names
 			metrics: [metric],
 		});
 		const { reason, result, details } = output;
+		/* The custom command will return 'pass' if the test falls within the predicted baseline
+ 		 * or 'fail'  if the performance metric falls outside the predicted baseline.
+		 * customers can decide how strict they want to be in failing tests by setting thier own
+		 * failure points.
+		 * assert(details[metric].actual < 5000, true, reason);
+		 */
 		return result !== 'pass'
 			? assert.equal(details[metric].actual < 5000, true, reason)
 			: assert(result, 'pass');

--- a/WebdriverJs-Mocha/tests/performance.js
+++ b/WebdriverJs-Mocha/tests/performance.js
@@ -74,13 +74,11 @@ describe('Performance Testing', () => { // eslint-disable-line func-names
 			name: capabilities.name,
 			metrics: [metric],
 		});
+
 		const { reason, result, details } = output;
-		// it the test returns a failure, make sure the load time is not over 5s
-		if (result !== 'pass') {
-			assert.equal(details[metric.actual] < 5000, true, reason);
-			return;
-		}
-		assert(result, 'pass');
+		return result !== 'pass'
+			? assert.equal(details[metric].actual < 5000, true, reason)
+			: assert(result, 'pass');
 	});
 
 	it('(sauce:performance) custom command should assert timeToFirstInteractive has not regressed', async () => {
@@ -91,12 +89,10 @@ describe('Performance Testing', () => { // eslint-disable-line func-names
 			name: capabilities.name,
 			metrics: [metric],
 		});
+
 		const { reason, result, details } = output;
-		// it the test returns a failure, make sure the timeToFirstInteractive is not over 5s
-		if (result !== 'pass') {
-			assert.equal(details[metric.actual] < 5000, true, reason);
-			return;
-		}
-		assert(result, 'pass');
+		return result !== 'pass'
+			? assert.equal(details[metric.actual] < 5000, true, reason)
+			: assert(result, 'pass');
 	});
 });

--- a/WebdriverJs-Mocha/tests/performance.js
+++ b/WebdriverJs-Mocha/tests/performance.js
@@ -91,6 +91,12 @@ describe('Performance Testing', () => { // eslint-disable-line func-names
 		});
 
 		const { reason, result, details } = output;
+		/* The custom command will return 'pass' if the test falls within the predicted baseline
+ 		 * or 'fail'  if the performance metric falls outside the predicted baseline.
+ 		 * customers can decide how strict they want to be in failing tests by setting thier own
+ 		 * failure points.
+ 		 * assert(details[metric].actual < 5000, true, reason);
+		 */
 		return result !== 'pass'
 			? assert.equal(details[metric.actual] < 5000, true, reason)
 			: assert(result, 'pass');

--- a/WebdriverJs-Mocha/tests/performance.js
+++ b/WebdriverJs-Mocha/tests/performance.js
@@ -69,21 +69,34 @@ describe('Performance Testing', () => { // eslint-disable-line func-names
 	it('(sauce:performance) custom command should assert pageLoad has not regressed', async () => {
 		await timeout(3000);
 		driver.sleep(20000);
-
+		const metric = 'load';
 		const output = await driver.executeScript('sauce:performance', {
 			name: capabilities.name,
-			metrics: ['load'],
+			metrics: [metric],
 		});
-		assert.equal(output.result, 'pass', output.reason);
+		const { reason, result, details } = output;
+		// it the test returns a failure, make sure the load time is not over 5s
+		if (result !== 'pass') {
+			assert.equal(details[metric.actual] < 5000, true, reason);
+			return;
+		}
+		assert(result, 'pass');
 	});
 
 	it('(sauce:performance) custom command should assert timeToFirstInteractive has not regressed', async () => {
 		await timeout(3000);
 		driver.sleep(20000);
+		const metric = 'timeToFirstInteractive';
 		const output = await driver.executeScript('sauce:performance', {
 			name: capabilities.name,
-			metrics: ['timeToFirstInteractive'],
+			metrics: [metric],
 		});
-		assert.equal(output.result, 'pass', output.reason);
+		const { reason, result, details } = output;
+		// it the test returns a failure, make sure the timeToFirstInteractive is not over 5s
+		if (result !== 'pass') {
+			assert.equal(details[metric.actual] < 5000, true, reason);
+			return;
+		}
+		assert(result, 'pass');
 	});
 });

--- a/WebdriverJs-Mocha/tests/performance.js
+++ b/WebdriverJs-Mocha/tests/performance.js
@@ -32,7 +32,7 @@ describe('Performance Testing', () => { // eslint-disable-line func-names
 		await driver.get('https://www.saucedemo.com/');
 		await driver.findElement(By.css('[data-test="username"]')).sendKeys(process.env.PERF_USERNAME || 'standard_user');
 		await driver.findElement(By.css('[data-test="password"]')).sendKeys('secret_sauce');
-		await driver.findElement(By.css('.login-button')).click();
+		await driver.findElement(By.css('.btn_action')).click();
 	});
 
 	afterEach(function hook() {
@@ -77,12 +77,12 @@ describe('Performance Testing', () => { // eslint-disable-line func-names
 		assert.equal(output.result, 'pass', output.reason);
 	});
 
-	it('(sauce:performance) custom command should assert speedIndex has not regressed', async () => {
+	it('(sauce:performance) custom command should assert timeToFirstInteractive has not regressed', async () => {
 		await timeout(3000);
 		driver.sleep(20000);
 		const output = await driver.executeScript('sauce:performance', {
 			name: capabilities.name,
-			metrics: ['speedIndex'],
+			metrics: ['timeToFirstInteractive'],
 		});
 		assert.equal(output.result, 'pass', output.reason);
 	});


### PR DESCRIPTION
Fix:
* login tests were broken

Also updated test assertions. Currently tests can be flaky if the test is a little outside the baseline.  I added a conditional to only fail the baseline if the result is greater than 5s.

Let me know if what you think of this approach, it teaches the user they can set their own thresholds for failure.

